### PR TITLE
Appveyor script for both Windows and Linux using Node 8 LTS and Node 10 LTS 

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,15 +1,17 @@
 image:
-  - Visual Studio 2017
   - Ubuntu
-# Test against the latest version of this Node.js version
+  - Visual Studio 2015
+
 environment:
   matrix:
     - nodejs_version: "8"
     - nodejs_version: "10"
 
+# Fail on first error
 matrix:
   fast_finish: true
 
+# Specify cache for yarn in cross platform way
 for:
 -
   matrix:
@@ -22,15 +24,19 @@ for:
     only:
       - image: Ubuntu
   cache:
-    - "~/.cache/yarn"
+    - "$HOME/.cache/yarn"
 
 shallow_clone: true
 
-# Install scripts. (runs after repo cloning)
 install:
-  # Get the latest stable version of Node.js or io.js
-  - ps: Install-Product node $env:nodejs_version
-  # install modules
+  # Install specified version of Node.JS (cross platform capable way)
+  - cmd: powershell Install-Product node $env:nodejs_version
+  - sh: nvm install $nodejs_version
+
+  # Set execution flag on script that runs inside docker
+  - sh: chmod +x ./scripts/build-prod.sh
+
+  # install dependencies
   - yarn install
   - yarn build
 
@@ -40,7 +46,7 @@ test_script:
   - yarn --version
   - node --version
   - npm --version
-  # run tests
+  # Run all tests
   - yarn lint
   - yarn test:unit
   - yarn test:nsp
@@ -49,5 +55,3 @@ test_script:
 
 # Don't actually build.
 build: off
-
-

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,8 @@ environment:
     - nodejs_version: "8"
     - nodejs_version: "10"
 
-fast_finish: true
+matrix:
+  fast_finish: true
 
 for:
 -

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,14 +1,27 @@
+image:
+  - Visual Studio 2017
+  - Ubuntu
 # Test against the latest version of this Node.js version
 environment:
   matrix:
     - nodejs_version: "8"
     - nodejs_version: "10"
-matrix:
-  fast_finish: true
 
-cache:
-  - '%LOCALAPPDATA%\Yarn'
-  - '%APPDATA%\npm-cache'               # npm cache
+fast_finish: true
+
+for:
+-
+  matrix:
+    except:
+      - image: Ubuntu
+  cache:
+    - "%LOCALAPPDATA%\\Yarn"
+-
+  matrix:
+    only:
+      - image: Ubuntu
+  cache:
+    - "~/.cache/yarn"
 
 shallow_clone: true
 
@@ -17,7 +30,7 @@ install:
   # Get the latest stable version of Node.js or io.js
   - ps: Install-Product node $env:nodejs_version
   # install modules
-  - npm install
+  - yarn install
   - yarn build
 
 # Post-install test scripts.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+# Test against the latest version of this Node.js version
+environment:
+  nodejs_version: "6"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+
+# Don't actually build.
+build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,5 +18,12 @@ test_script:
   - npm --version
   # run tests
 
+
 # Don't actually build.
-build: off
+build:
+  - yarn build
+  - yarn test:unit
+  - yarn lint
+  - yarn test:nsp
+  - yarn test:integration
+  - yarn doc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # Test against the latest version of this Node.js version
 environment:
-  nodejs_version: "6"
+  nodejs_version: "8"
 
 # Install scripts. (runs after repo cloning)
 install:
@@ -8,15 +8,15 @@ install:
   - ps: Install-Product node $env:nodejs_version
   # install modules
   - npm install -g yarn
-  - yarn install
+  - npm install
 
 # Post-install test scripts.
 test_script:
   # Output useful info for debugging.
+  - yarn --version
   - node --version
   - npm --version
   # run tests
-  - npm test
 
 # Don't actually build.
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,13 +2,16 @@
 environment:
   nodejs_version: "8"
 
+cache:
+ - "%LOCALAPPDATA%\\Yarn"
+
 # Install scripts. (runs after repo cloning)
 install:
   # Get the latest stable version of Node.js or io.js
   - ps: Install-Product node $env:nodejs_version
   # install modules
-  - npm install -g yarn
-  - npm install
+  - yarn install
+  - yarn build
 
 # Post-install test scripts.
 test_script:
@@ -17,13 +20,12 @@ test_script:
   - node --version
   - npm --version
   # run tests
-
-
-# Don't actually build.
-build:
-  - yarn build
-  - yarn test:unit
   - yarn lint
+  - yarn test:unit
   - yarn test:nsp
   - yarn test:integration
   - yarn doc
+
+# Don't actually build.
+build: off
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,8 @@ install:
   # Get the latest stable version of Node.js or io.js
   - ps: Install-Product node $env:nodejs_version
   # install modules
-  - npm install
+  - npm install -g yarn
+  - yarn install
 
 # Post-install test scripts.
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,10 @@
 # Test against the latest version of this Node.js version
 environment:
   matrix:
-    nodejs_version: "6"
-    nodejs_version: "7"
-    nodejs_version: "8"
-    nodejs_version: "9"
+    - nodejs_version: "6"
+    - nodejs_version: "7"
+    - nodejs_version: "8"
+    - nodejs_version: "9"
 
 cache:
  - "%LOCALAPPDATA%\\Yarn"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,10 @@
 # Test against the latest version of this Node.js version
 environment:
-  nodejs_version: "8"
+  matrix:
+    nodejs_version: "6"
+    nodejs_version: "7"
+    nodejs_version: "8"
+    nodejs_version: "9"
 
 cache:
  - "%LOCALAPPDATA%\\Yarn"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,20 +1,23 @@
 # Test against the latest version of this Node.js version
 environment:
   matrix:
-    - nodejs_version: "6"
-    - nodejs_version: "7"
     - nodejs_version: "8"
-    - nodejs_version: "9"
+    - nodejs_version: "10"
+matrix:
+  fast_finish: true
 
 cache:
- - "%LOCALAPPDATA%\\Yarn"
+  - '%LOCALAPPDATA%\Yarn'
+  - '%APPDATA%\npm-cache'               # npm cache
+
+shallow_clone: true
 
 # Install scripts. (runs after repo cloning)
 install:
   # Get the latest stable version of Node.js or io.js
   - ps: Install-Product node $env:nodejs_version
   # install modules
-  - yarn install
+  - npm install
   - yarn build
 
 # Post-install test scripts.
@@ -32,4 +35,5 @@ test_script:
 
 # Don't actually build.
 build: off
+
 

--- a/scripts/test-integration.js
+++ b/scripts/test-integration.js
@@ -1,43 +1,43 @@
-const cp = require("child_process");
+const cp = require('child_process');
 
 function isDockerInstalled() {
-    let result = true;
-    try {
-        cp.execSync("docker version");
-    } catch (err) {
-        result = false;
-    }
-    return result;
-};
+  let result = true;
+  try {
+    cp.execSync('docker version');
+  } catch (err) {
+    result = false;
+  }
+  return result;
+}
 
 function runIntegrationTests() {
+  if (isDockerInstalled()) {
+    const cmds = [
+      {
+        comment: '### 1. building a kalimdor docker image',
+        cmd: 'docker build -t kalimdor:latest .'
+      },
+      {
+        comment: '### 2. Running build-prod.sh in a temporary container',
+        cmd: "docker run --rm kalimdor:latest './scripts/build-prod.sh'"
+      }
+    ];
 
-    if (isDockerInstalled()) {
-        const cmds = [
-            {
-                comment: "### 1. building a kalimdor docker image",
-                cmd: "docker build -t kalimdor:latest ."
-            },
-            {
-                comment: "### 2. Running build-prod.sh in a temporary container",
-                cmd: "docker run --rm -it kalimdor:latest './scripts/build-prod.sh'"
-            },
-        ];
-
-        for (let i = 0; i < cmds.length; i++) {
-            console.log(cmds[i].comment);
-            cp.execSync(cmds[i].cmd, { stdio: [0, 1, 2] });
-        }
-
-    } else {
-        console.warn("Docker does not seem to be properly installed. Skipping integration tests.");
+    for (let i = 0; i < cmds.length; i++) {
+      console.log(cmds[i].comment);
+      cp.execSync(cmds[i].cmd, { stdio: [0, 1, 2] });
     }
+  } else {
+    console.warn(
+      'Docker does not seem to be properly installed. Skipping integration tests.'
+    );
+  }
 }
 
 try {
-    runIntegrationTests();
-    console.log("PASS Integration tests");
+  runIntegrationTests();
+  console.log('PASS Integration tests');
 } catch (err) {
-    console.error("FAILED Integration tests");
-    process.exitCode = 1;
+  console.error('FAILED Integration tests');
+  process.exitCode = 1;
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds support for building Kalimdor.JS via Appveyor for both Windows and Linux. 


* **What is the current behavior?** (You can also link to an open issue here)
Kalimdor.JS is currently build via Travis for Linux only. 
See Issue here: https://github.com/kalimdorjs/kalimdorjs/issues/87


* **What is the new behavior (if this is a feature change)?**
Building and testing via Appveyor 


* **Other information**:

- In order to enable your build for Appveyor, you need an Appveyor account and add Kalimdor.JS as project. Then it will run on commits on every branch. 
- After adding Kalimdor.JS to Appveyor you'll find the URLs for the building badges to be included in README.md under Projects --> kalimdorjs --> Settings --> Badges
- Building the docker image during integration test is disabled for Windows for now because by default Docker for Windows which is pre-installed on Apveyor's machines is only accepting Windows container.