### PR TITLE
feature/mean_squared_error

### DIFF
--- a/src/lib/metrics/index.repl.ts
+++ b/src/lib/metrics/index.repl.ts
@@ -42,3 +42,15 @@ const matrix3 = confusion_matrix({
 });
 
 console.log(matrix3);
+
+import { mean_squared_error } from './regression';
+
+const y_true = [3, -0.5, 2, 7];
+const y_pred = [2.5, 0.0, 2, 8];
+
+console.log(mean_squared_error(y_true, y_pred));
+
+const y_true1 = [[0.5, 1], [-1, 1], [7, -6]];
+const y_pred1 = [[0, 2], [-1, 2], [8, -5]];
+
+console.log(mean_squared_error(y_true1, y_pred1));

--- a/src/lib/metrics/index.ts
+++ b/src/lib/metrics/index.ts
@@ -1,3 +1,4 @@
 import { accuracyScore, confusion_matrix, zeroOneLoss } from './classification';
+import { mean_squared_error } from './regression';
 
-export { accuracyScore, confusion_matrix, zeroOneLoss };
+export { accuracyScore, confusion_matrix, mean_squared_error, zeroOneLoss };

--- a/src/lib/metrics/regression.ts
+++ b/src/lib/metrics/regression.ts
@@ -1,9 +1,17 @@
 import * as tf from '@tensorflow/tfjs';
+import { isEqual } from 'lodash';
+import { inferShape } from '../ops';
 import { Type1DMatrix, Type2DMatrix } from '../types';
 
+/**
+ * Mean squared error regression loss
+ * @param y_true - Ground truth (correct) target values.
+ * @param y_pred - Estimated target values.
+ * @param sample_weight - Sample weights.
+ */
 export const mean_squared_error = (
-  y_true: Type1DMatrix<number> | Type2DMatrix<number>,
-  y_pred: Type1DMatrix<number> | Type2DMatrix<number>,
+  y_true: Type1DMatrix<number> | Type2DMatrix<number> = null,
+  y_pred: Type1DMatrix<number> | Type2DMatrix<number> = null,
   // Options
   {
     sample_weight = null
@@ -13,6 +21,28 @@ export const mean_squared_error = (
     sample_weight: null
   }
 ): number => {
+  // console.log(inferShape(y_true));
+  const yTrueShape = inferShape(y_true);
+  const yPredShape = inferShape(y_pred);
+
+  // Validation 1: empty array check
+  if (yTrueShape[0] === 0 || yPredShape[0] === 0) {
+    throw new TypeError(
+      `y_true ${JSON.stringify(y_true)} and y_pred ${JSON.stringify(
+        y_pred
+      )} cannot be empty`
+    );
+  }
+
+  // Validation 2: Same shape
+  if (!isEqual(y_true, y_pred)) {
+    throw new TypeError(
+      `Shapes of y_true ${JSON.stringify(
+        yTrueShape
+      )} and y_pred ${JSON.stringify(yPredShape)} should be equal`
+    );
+  }
+
   return tf.losses
     .meanSquaredError(y_true, y_pred, sample_weight)
     .dataSync()[0];

--- a/src/lib/metrics/regression.ts
+++ b/src/lib/metrics/regression.ts
@@ -5,22 +5,40 @@ import { Type1DMatrix, Type2DMatrix } from '../types';
 
 /**
  * Mean squared error regression loss
+ *
+ * @example
+ * import { mean_squared_error } from 'kalimdor/metrics';
+ *
+ * const y_true = [3, -0.5, 2, 7];
+ * const y_pred = [2.5, 0.0, 2, 8];
+ *
+ * console.log(mean_squared_error(y_true, y_pred));
+ * // result: 0.375
+ *
+ * const y_true1 = [[0.5, 1], [-1, 1], [7, -6]];
+ * const y_pred1 = [[0, 2], [-1, 2], [8, -5]];
+ *
+ * console.log(mean_squared_error(y_true1, y_pred1));
+ * // result: 0.7083333134651184
+ *
  * @param y_true - Ground truth (correct) target values.
  * @param y_pred - Estimated target values.
- * @param sample_weight - Sample weights.
  */
-export const mean_squared_error = (
+export function mean_squared_error(
   y_true: Type1DMatrix<number> | Type2DMatrix<number> = null,
   y_pred: Type1DMatrix<number> | Type2DMatrix<number> = null,
   // Options
   {
+    /**
+     * Sample weights.
+     */
     sample_weight = null
   }: {
     sample_weight: number;
   } = {
     sample_weight: null
   }
-): number => {
+): number {
   // console.log(inferShape(y_true));
   const yTrueShape = inferShape(y_true);
   const yPredShape = inferShape(y_pred);
@@ -35,7 +53,7 @@ export const mean_squared_error = (
   }
 
   // Validation 2: Same shape
-  if (!isEqual(y_true, y_pred)) {
+  if (!isEqual(yTrueShape, yPredShape)) {
     throw new TypeError(
       `Shapes of y_true ${JSON.stringify(
         yTrueShape
@@ -46,4 +64,4 @@ export const mean_squared_error = (
   return tf.losses
     .meanSquaredError(y_true, y_pred, sample_weight)
     .dataSync()[0];
-};
+}

--- a/src/lib/metrics/regression.ts
+++ b/src/lib/metrics/regression.ts
@@ -1,0 +1,19 @@
+import * as tf from '@tensorflow/tfjs';
+import { Type1DMatrix, Type2DMatrix } from '../types';
+
+export const mean_squared_error = (
+  y_true: Type1DMatrix<number> | Type2DMatrix<number>,
+  y_pred: Type1DMatrix<number> | Type2DMatrix<number>,
+  // Options
+  {
+    sample_weight = null
+  }: {
+    sample_weight: number;
+  } = {
+    sample_weight: null
+  }
+): number => {
+  return tf.losses
+    .meanSquaredError(y_true, y_pred, sample_weight)
+    .dataSync()[0];
+};

--- a/test/metrics/__snapshots__/regression.test.ts.snap
+++ b/test/metrics/__snapshots__/regression.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`metrics:mean_squared_error should throw an exception if inputs' shapes are different 1`] = `[TypeError: Shapes of y_true [3,2] and y_pred [2] should be equal]`;
+
+exports[`metrics:mean_squared_error should throw an exception if inputs' shapes are different 2`] = `[TypeError: Shapes of y_true [2] and y_pred [3,2] should be equal]`;
+
+exports[`metrics:mean_squared_error should throw an exception if inputs' shapes are different 3`] = `[TypeError: Shapes of y_true [4] and y_pred [3,2] should be equal]`;
+
+exports[`metrics:mean_squared_error should throw an exception if inputs' shapes are different 4`] = `[Error: values passed to tensor(values) must be an array of numbers or booleans, or a TypedArray]`;

--- a/test/metrics/regression.test.ts
+++ b/test/metrics/regression.test.ts
@@ -1,0 +1,25 @@
+import { mean_squared_error } from '../../src/lib/metrics';
+import { matchExceptionWithSnapshot } from '../util_testing';
+
+describe('metrics:mean_squared_error', () => {
+  const yTrue1 = [3, -0.5, 2, 7];
+  const yPred1 = [2.5, 0.0, 2, 8];
+  const yTrue2 = [[0.5, 1], [-1, 1], [7, -6]];
+  const yPred2 = [[0, 2], [-1, 2], [8, -5]];
+  it('should calculate MSE of yTrue1 and yPred1 then return 0.375', () => {
+    const error = mean_squared_error(yTrue1, yPred1);
+    expect(error).toBe(0.375);
+  });
+
+  it('should calculate MSE of yTure2 and yPred2 then return 0.7083333134651184', () => {
+    const error = mean_squared_error(yTrue2, yPred2);
+    expect(error).toBe(0.7083333134651184);
+  });
+
+  it("should throw an exception if inputs' shapes are different", () => {
+    matchExceptionWithSnapshot(mean_squared_error, [yTrue2, [1, 2]]);
+    matchExceptionWithSnapshot(mean_squared_error, [[1, 2], yTrue2]);
+    matchExceptionWithSnapshot(mean_squared_error, [yTrue1, yTrue2]);
+    matchExceptionWithSnapshot(mean_squared_error, [null, null]);
+  });
+});


### PR DESCRIPTION
Implemented MSE regression metrics. It is based on https://js.tensorflow.org/api/latest/#losses.meanSquaredError and referenced https://www.statisticshowto.datasciencecentral.com/mean-squared-error/

TODO:
- (/) Write unit tests
- (/) Documentation
- (!) MSE documentation displays `Type1DMatrix or Type2DMatrix`, instead, we want `number[] or number[][]` -> We should deal with this issue in a separate ticket.