### PR TITLE
feature/v2_mean_absolute_error

### DIFF
--- a/src/lib/metrics/index.repl.ts
+++ b/src/lib/metrics/index.repl.ts
@@ -43,7 +43,7 @@ const matrix3 = confusion_matrix({
 
 console.log(matrix3);
 
-import { mean_squared_error } from './regression';
+import { mean_absolute_error, mean_squared_error } from './regression';
 
 const y_true = [3, -0.5, 2, 7];
 const y_pred = [2.5, 0.0, 2, 8];
@@ -54,3 +54,12 @@ const y_true1 = [[0.5, 1], [-1, 1], [7, -6]];
 const y_pred1 = [[0, 2], [-1, 2], [8, -5]];
 
 console.log(mean_squared_error(y_true1, y_pred1));
+
+console.log(mean_absolute_error([3, -0.5, 2, 7], [2.5, 0.0, 2, 8]));
+console.log(
+  mean_absolute_error(
+    [[0.5, 1], [-1, 1], [7, -6]],
+    [[0, 2], [-1, 2], [8, -5]],
+    { sample_weight: [1, 2] }
+  )
+);

--- a/src/lib/metrics/index.ts
+++ b/src/lib/metrics/index.ts
@@ -1,4 +1,10 @@
 import { accuracyScore, confusion_matrix, zeroOneLoss } from './classification';
-import { mean_squared_error } from './regression';
+import { mean_absolute_error, mean_squared_error } from './regression';
 
-export { accuracyScore, confusion_matrix, mean_squared_error, zeroOneLoss };
+export {
+  accuracyScore,
+  confusion_matrix,
+  mean_absolute_error,
+  mean_squared_error,
+  zeroOneLoss
+};

--- a/src/lib/metrics/regression.ts
+++ b/src/lib/metrics/regression.ts
@@ -28,6 +28,35 @@ export function mean_absolute_error(
     sample_weight: null
   }
 ): number {
+  const yTrueShape = inferShape(y_true);
+  const yPredShape = inferShape(y_pred);
+
+  // Validation 1: empty array check
+  if (yTrueShape[0] === 0 || yPredShape[0] === 0) {
+    throw new TypeError(
+      `y_true ${JSON.stringify(y_true)} and y_pred ${JSON.stringify(
+        y_pred
+      )} cannot be empty`
+    );
+  }
+
+  if (sample_weight !== null) {
+    const weightShape = inferShape(sample_weight);
+    if (!isEqual(yTrueShape, weightShape)) {
+      throw new TypeError(`The shape of ${JSON.stringify(weightShape)}
+       does not match with the sample size ${JSON.stringify(yTrueShape)}`);
+    }
+  }
+
+  // Validation 2: Same shape
+  if (!isEqual(yTrueShape, yPredShape)) {
+    throw new TypeError(
+      `The shapes of y_true ${JSON.stringify(
+        yTrueShape
+      )} and y_pred ${JSON.stringify(yPredShape)} should be equal`
+    );
+  }
+
   /**
    * Compute the weighted average along the specified axis.
    *
@@ -97,7 +126,6 @@ export function mean_squared_error(
     sample_weight: null
   }
 ): number {
-  // console.log(inferShape(y_true));
   const yTrueShape = inferShape(y_true);
   const yPredShape = inferShape(y_pred);
 

--- a/src/lib/metrics/regression.ts
+++ b/src/lib/metrics/regression.ts
@@ -4,6 +4,64 @@ import { inferShape } from '../ops';
 import { Type1DMatrix, Type2DMatrix } from '../types';
 
 /**
+ * Mean absolute error regression loss
+ *
+ * @example
+ * import { mean_absolute_error } from 'kalimdor/metrics';
+ * const y_true = [3, -0.5, 2, 7]
+ * const y_pred = [2.5, 0.0, 2, 8]
+ * mean_absolute_error(y_true, y_pred); // 0.5
+ *
+ * @param y_true - Ground truth (correct) target values.
+ * @param y_pred - Estimated target values.
+ * @param sample_weight - Sample weights.
+ */
+export function mean_absolute_error(
+  y_true: Type1DMatrix<number> | Type2DMatrix<number> = null,
+  y_pred: Type1DMatrix<number> | Type2DMatrix<number> = null,
+  // Options
+  {
+    sample_weight = null
+  }: {
+    sample_weight: Type1DMatrix<number>;
+  } = {
+    sample_weight: null
+  }
+): number {
+  /**
+   * Compute the weighted average along the specified axis.
+   *
+   * @example
+   * average(tf.tensor1d([1, 2, 3, 4])).dataSync(); // [2.5]
+   *
+   * @param X - Array containing data to be averaged. If a is not an array, a conversion is attempted.
+   * @param axis - Axis along which to average a. If None, averaging is done over the flattened array.
+   * @param w - An array of weights associated with the values in a. Each value in a contributes to the average according to its associated weight. The weights array can either be 1-D (in which case its length must be the size of a along the given axis) or of the same shape as a. If weights=None, then all data in a are assumed to have a weight equal to one.
+   * @ignore
+   */
+  const average = (
+    X: tf.Tensor,
+    axis: number = 0,
+    w: Type1DMatrix<number> | null = null
+  ): tf.Tensor => {
+    if (w !== null) {
+      const wgt = tf.tensor1d(w);
+      const scl = wgt.sum(axis);
+      return tf
+        .mul(X, wgt)
+        .sum(axis)
+        .div(scl);
+    } else {
+      const sample_size = X.size;
+      return tf.div(tf.sum(X), tf.scalar(sample_size));
+    }
+  };
+  const output_errors = tf.abs(tf.sub(y_true, y_pred));
+  const avg_errors = average(output_errors, 0, sample_weight);
+  return average(avg_errors).dataSync()[0];
+}
+
+/**
  * Mean squared error regression loss
  *
  * @example

--- a/test/integration/require.test.ts
+++ b/test/integration/require.test.ts
@@ -46,10 +46,14 @@ describe('integration:require', () => {
     const {
       accuracyScore,
       confusion_matrix,
-      zeroOneLoss
+      zeroOneLoss,
+      mean_absolute_error,
+      mean_squared_error
     } = require('kalimdor/metrics');
     expect(!!accuracyScore).toBe(true);
     expect(!!confusion_matrix).toBe(true);
+    expect(!!mean_absolute_error).toBe(true);
+    expect(!!mean_squared_error).toBe(true);
     expect(!!zeroOneLoss).toBe(true);
   });
 

--- a/test/metrics/__snapshots__/regression.test.ts.snap
+++ b/test/metrics/__snapshots__/regression.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`metrics:mean_absolute_error should reject invalid inputs 1`] = `[Error: values passed to tensor(values) must be an array of numbers or booleans, or a TypedArray]`;
+
+exports[`metrics:mean_absolute_error should reject invalid inputs 2`] = `[Error: values passed to tensor(values) must be an array of numbers or booleans, or a TypedArray]`;
+
+exports[`metrics:mean_absolute_error should reject invalid inputs 3`] = `[TypeError: The shapes of y_true [3] and y_pred [2] should be equal]`;
+
+exports[`metrics:mean_absolute_error should reject invalid inputs 4`] = `
+[TypeError: The shape of [1]
+       does not match with the sample size [2]]
+`;
+
 exports[`metrics:mean_squared_error should throw an exception if inputs' shapes are different 1`] = `[TypeError: Shapes of y_true [3,2] and y_pred [2] should be equal]`;
 
 exports[`metrics:mean_squared_error should throw an exception if inputs' shapes are different 2`] = `[TypeError: Shapes of y_true [2] and y_pred [3,2] should be equal]`;

--- a/test/metrics/regression.test.ts
+++ b/test/metrics/regression.test.ts
@@ -1,7 +1,4 @@
-import {
-  mean_absolute_error,
-  nmean_squared_error
-} from '../../src/lib/metrics';
+import { mean_absolute_error, mean_squared_error } from '../../src/lib/metrics';
 import { matchExceptionWithSnapshot } from '../util_testing';
 
 describe('metrics:mean_absolute_error', () => {

--- a/test/metrics/regression.test.ts
+++ b/test/metrics/regression.test.ts
@@ -26,7 +26,17 @@ describe('metrics:mean_absolute_error', () => {
     });
     expect(error).toBe(0.550000011920929);
   });
-  // TODO: Add exception tests
+  it('should reject invalid inputs', () => {
+    matchExceptionWithSnapshot(mean_absolute_error, [null, null]);
+    matchExceptionWithSnapshot(mean_absolute_error, [1, 2]);
+    matchExceptionWithSnapshot(mean_absolute_error, ['test', 'zz']);
+    matchExceptionWithSnapshot(mean_absolute_error, [[1, 2, 3], [4, 5]]);
+    matchExceptionWithSnapshot(mean_absolute_error, [
+      [1, 2],
+      [3, 4],
+      { sample_weight: [1] }
+    ]);
+  });
 });
 
 describe('metrics:mean_squared_error', () => {

--- a/test/metrics/regression.test.ts
+++ b/test/metrics/regression.test.ts
@@ -1,5 +1,33 @@
-import { mean_squared_error } from '../../src/lib/metrics';
+import {
+  mean_absolute_error,
+  nmean_squared_error
+} from '../../src/lib/metrics';
 import { matchExceptionWithSnapshot } from '../util_testing';
+
+describe('metrics:mean_absolute_error', () => {
+  const yTrue1 = [3, -0.5, 2, 7];
+  const yPred1 = [2.5, 0.0, 2, 8];
+  const yTrue2 = [[0.5, 1], [-1, 1], [7, -6]];
+  const yPred2 = [[0, 2], [-1, 2], [8, -5]];
+
+  it('should calculate MAE of yTrue1 and yPred1 then return 0.5', () => {
+    const error = mean_absolute_error(yTrue1, yPred1);
+    expect(error).toBe(0.5);
+  });
+
+  it('should calculate MAE of yTrue2 and yPred2 then return 0.75', () => {
+    const error = mean_absolute_error(yTrue2, yPred2);
+    expect(error).toBe(0.75);
+  });
+
+  it('should calculate MAE of yTrue1 and yPred1 with weights [1, 2] then', () => {
+    const error = mean_absolute_error(yTrue1, yPred1, {
+      sample_weight: [1, 2, 3, 4]
+    });
+    expect(error).toBe(0.550000011920929);
+  });
+  // TODO: Add exception tests
+});
 
 describe('metrics:mean_squared_error', () => {
   const yTrue1 = [3, -0.5, 2, 7];


### PR DESCRIPTION
mean_absolute_error implementation with sample_weights support.

Please read more about this API at https://scikit-learn.org/stable/modules/generated/sklearn.metrics.mean_absolute_error.html#sklearn.metrics.mean_absolute_error


TODO:
- [/] Add unit tests
- [/] Add integration tests