### PR TITLE
refactor/PCA to tfjs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.0]
+
+:rocket: Version 2 release! :rocket:
+
+- **enhance:** PCA refactored to tfjs-core
+
 ## [1.2.5]
 
 :bug: removing a module for a security reason :bug:

--- a/src/lib/decomposition/pca.ts
+++ b/src/lib/decomposition/pca.ts
@@ -1,6 +1,6 @@
 import * as tf from '@tensorflow/tfjs';
 import * as numeric from 'numeric';
-import { reshape, validateMatrix2D } from '../ops';
+import { reshape, validateMatrix2D, validateMatrixType } from '../ops';
 import { IMlModel, Type2DMatrix } from '../types';
 
 /**
@@ -45,6 +45,7 @@ export class PCA implements IMlModel<number> {
    */
   public fit(X: Type2DMatrix<number>): void {
     validateMatrix2D(X);
+    validateMatrixType(X, ['number']);
     const nSamples = X.length;
     // Renaming X to A for readability
     const A = tf.tensor2d(X);

--- a/src/lib/decomposition/pca.ts
+++ b/src/lib/decomposition/pca.ts
@@ -1,3 +1,4 @@
+// import * as tf from '@tensorflow/tfjs';
 import * as numeric from 'numeric';
 import { validateMatrix2D } from '../ops';
 import { IMlModel, Type2DMatrix } from '../types';
@@ -48,9 +49,25 @@ export class PCA implements IMlModel<number> {
     const nSamples = X.length;
     // Renaming X to A for readability
     const A = X;
+    // const AT1 = tf.transpose(A, [1, 0]).dataSync();
     const AT = math.transpose(A);
+    // console.log('transpose tfjs', AT1);
+    // console.log('transpose mathjs', AT);
+
+    // const M1 = tf.mean(AT1);
     const M = math.mean(AT, 1);
+    /*
+    console.log(
+      'TFjs mean',
+      M1.dataSync(),
+      tf.mean([[1, 3, 5], [2, 4, 6]], [1, 0], true).dataSync()
+    );
+    console.log('mathjs mean', M);
+    */
+
+    // const C = tf.sub(X, M).dataSync();
     const C = math.contrib.subtract(X, M);
+
     const svd = numeric.svd(C);
     this.components = svd.V;
     this.explained_variance = numeric.div(numeric.pow(svd.U), nSamples - 1);

--- a/src/lib/decomposition/pca.ts
+++ b/src/lib/decomposition/pca.ts
@@ -2,7 +2,6 @@ import * as tf from '@tensorflow/tfjs';
 import * as numeric from 'numeric';
 import { reshape, validateMatrix2D } from '../ops';
 import { IMlModel, Type2DMatrix } from '../types';
-import math from '../utils/MathExtra';
 
 /**
  * Principal component analysis (PCA)
@@ -48,26 +47,14 @@ export class PCA implements IMlModel<number> {
     validateMatrix2D(X);
     const nSamples = X.length;
     // Renaming X to A for readability
-    const A = X;
+    const A = tf.tensor2d(X);
 
-    const transposed = tf.transpose(A, [1, 0]);
-    const transposedShape = transposed.shape;
-    const AT: any = reshape([...transposed.dataSync()], transposedShape);
+    // const transposed = tf.transpose(A, [1, 0]);
+    const AT = tf.transpose(A, [1, 0]);
 
-    // const M1 = tf.mean(AT1);
-    const M = math.mean(AT, 1);
-    /*
-    console.log(
-      'TFjs mean',
-      M1.dataSync(),
-      tf.mean([[1, 3, 5], [2, 4, 6]], [1, 0], true).dataSync()
-    );
-    console.log('mathjs mean', M);
-    */
-
-    // const C = tf.sub(X, M).dataSync();
-    const C = math.contrib.subtract(X, M);
-
+    const M = tf.mean(AT, 1);
+    const rawC = tf.sub(A, M);
+    const C: any = reshape([...rawC.dataSync()], rawC.shape);
     const svd = numeric.svd(C);
     this.components = svd.V;
     this.explained_variance = numeric.div(numeric.pow(svd.U), nSamples - 1);

--- a/src/lib/decomposition/pca.ts
+++ b/src/lib/decomposition/pca.ts
@@ -1,6 +1,6 @@
-// import * as tf from '@tensorflow/tfjs';
+import * as tf from '@tensorflow/tfjs';
 import * as numeric from 'numeric';
-import { validateMatrix2D } from '../ops';
+import { reshape, validateMatrix2D } from '../ops';
 import { IMlModel, Type2DMatrix } from '../types';
 import math from '../utils/MathExtra';
 
@@ -49,10 +49,10 @@ export class PCA implements IMlModel<number> {
     const nSamples = X.length;
     // Renaming X to A for readability
     const A = X;
-    // const AT1 = tf.transpose(A, [1, 0]).dataSync();
-    const AT = math.transpose(A);
-    // console.log('transpose tfjs', AT1);
-    // console.log('transpose mathjs', AT);
+
+    const transposed = tf.transpose(A, [1, 0]);
+    const transposedShape = transposed.shape;
+    const AT: any = reshape([...transposed.dataSync()], transposedShape);
 
     // const M1 = tf.mean(AT1);
     const M = math.mean(AT, 1);

--- a/src/lib/ops/index.repl.ts
+++ b/src/lib/ops/index.repl.ts
@@ -1,6 +1,8 @@
 /* tslint:disable */
-import { inferShape } from './tensor_ops';
+import { inferShape, validateMatrixType } from './tensor_ops';
 
 const result = inferShape([[1, 2]]);
 
 console.log(result);
+
+console.log(validateMatrixType([['z', 'z']], ['string']));

--- a/src/lib/ops/index.ts
+++ b/src/lib/ops/index.ts
@@ -3,7 +3,8 @@ import {
   reshape,
   validateFitInputs,
   validateMatrix1D,
-  validateMatrix2D
+  validateMatrix2D,
+  validateMatrixType
 } from './tensor_ops';
 
 export {
@@ -11,5 +12,6 @@ export {
   validateFitInputs,
   validateMatrix1D,
   validateMatrix2D,
+  validateMatrixType,
   reshape
 };

--- a/src/lib/ops/tensor_ops.ts
+++ b/src/lib/ops/tensor_ops.ts
@@ -1,5 +1,5 @@
 import * as tf from '@tensorflow/tfjs';
-import { flattenDeep } from 'lodash';
+import { flattenDeep, isEqual, sortBy, uniq } from 'lodash';
 import { Type1DMatrix, Type2DMatrix, TypeMatrix } from '../types';
 
 /**
@@ -16,6 +16,37 @@ import { Type1DMatrix, Type2DMatrix, TypeMatrix } from '../types';
  */
 export function inferShape(X: TypeMatrix<any>): number[] {
   return tf.tensor(X).shape;
+}
+
+/**
+ * Validates the input matrix's types with the targetted types.
+ * Specified target types must be one of https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#Description
+ *
+ * @example
+ * validateMatrixType([['z', 'z']],['string']); // no errors
+ * validateMatrixType([['z', 'z']],['test']); // error: Input matrix type of ["string"] does not match with the target types ["test"]
+ *
+ * @param X - The input matrix
+ * @param targetTypes - Target matrix types
+ * @ignore
+ */
+export function validateMatrixType(
+  X: TypeMatrix<any>,
+  targetTypes: string[]
+): void {
+  const flatX = flattenDeep(X);
+  const xTypes = uniq(flatX.map(x => typeof x));
+  const sortedXTypes = sortBy(xTypes, x => x);
+  const sortedTargetTypes = sortBy(targetTypes, x => x);
+  if (!isEqual(sortedXTypes, sortedTargetTypes)) {
+    throw new TypeError(
+      `Input matrix type of ${JSON.stringify(
+        sortedXTypes
+      )} does not match with the target types ${JSON.stringify(
+        sortedTargetTypes
+      )}`
+    );
+  }
 }
 
 /**

--- a/test/decomposition/pca.test.ts
+++ b/test/decomposition/pca.test.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash';
 import { PCA } from '../../src/lib/decomposition';
 
 describe('decomposition:pca', () => {

--- a/test/decomposition/pca.test.ts
+++ b/test/decomposition/pca.test.ts
@@ -37,6 +37,8 @@ describe('decomposition:pca', () => {
 
   it('should throw an error when the given matrix is not all numbers', () => {
     const pca = new PCA();
-    expect(() => pca.fit(sample3)).toThrow('Cannot convert "test" to a number');
+    expect(() => pca.fit(sample3)).toThrow(
+      'Input matrix type of ["string"] does not match with the target types ["number"]'
+    );
   });
 });

--- a/test/ops/__snapshots__/tensor_ops.test.ts.snap
+++ b/test/ops/__snapshots__/tensor_ops.test.ts.snap
@@ -11,3 +11,7 @@ exports[`ops ops:validate1DMatrix should throw an exception when 1D matrix is no
 exports[`ops ops:validate2DMatrix should throw an exception when 2D matrix is not given 1`] = `[TypeError: The matrix is not 2D shaped: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2] of [150]]`;
 
 exports[`ops ops:validate2DMatrix should throw an exception when 2D matrix is not given 2`] = `[TypeError: The matrix is not 2D shaped: [1,2,3] of [3]]`;
+
+exports[`ops ops:validateMatrixType should not validate 1`] = `[TypeError: Input matrix type of ["number"] does not match with the target types ["string"]]`;
+
+exports[`ops ops:validateMatrixType should not validate 2`] = `[TypeError: Input matrix type of ["string"] does not match with the target types ["boolean"]]`;

--- a/test/ops/tensor_ops.test.ts
+++ b/test/ops/tensor_ops.test.ts
@@ -4,7 +4,8 @@ import {
   reshape,
   validateFitInputs,
   validateMatrix1D,
-  validateMatrix2D
+  validateMatrix2D,
+  validateMatrixType
 } from '../../src/lib/ops/tensor_ops';
 import { matchExceptionWithSnapshot } from '../util_testing';
 
@@ -69,6 +70,33 @@ describe('ops', () => {
     it('should throw an exception when 2D matrix is not given', () => {
       matchExceptionWithSnapshot(validateMatrix2D, [irisTargets]);
       matchExceptionWithSnapshot(validateMatrix2D, [y1]);
+    });
+  });
+
+  describe('ops:validateMatrixType', () => {
+    it('should validate', () => {
+      jest.setTimeout(10000);
+      // Number
+      validateMatrixType([1, 2, 3], ['number']);
+      validateMatrixType([[1, 2], [3, 4]], ['number']);
+      validateMatrixType([[[1, 2]], [[3, 4]]], ['number']);
+      // String
+      validateMatrixType(['1', '2', '3', '4'], ['string']);
+      validateMatrixType([['1', '2'], ['3', '4']], ['string']);
+      validateMatrixType([[['1', '2']], [['3', '4']]], ['string']);
+      // Complex type
+      validateMatrixType([[['1', 1]], [['3', 4]]], ['string', 'number']);
+      validateMatrixType(
+        [[['1', 1]], [['3', true]]],
+        ['string', 'number', 'boolean']
+      );
+    });
+    it('should not validate', () => {
+      matchExceptionWithSnapshot(validateMatrixType, [[1, 2, 3], ['string']]);
+      matchExceptionWithSnapshot(validateMatrixType, [
+        ['1', '2', '3', '4'],
+        ['boolean']
+      ]);
     });
   });
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Refactoring PCA to use tfjs-core Linear Algebra APIs. The PR includes:

- PCA refactor
   -> This is not 100% perfect since svd is still based on numeric.js's API
- validateMatrixType

