### PR TITLE
Fix/remove snyk from ci

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -48,7 +48,6 @@ test_script:
   - yarn lint
   - yarn doc
   - yarn test:unit
-  - npx snyk test
   - yarn test:integration
 
 # Don't actually build.

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,10 @@ cache:
 install:
   - npm install
   - npm install -g npx
-  - npx snyk auth $SNYK_TOKEN
 
 script:
   - yarn build
   - yarn doc
   - yarn test:unit
   - yarn lint
-  - npx snyk test
   - yarn test:integration

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "fix": "yarn fix:tslint",
     "fix:prettier": "npx prettier \"src/**/*.ts\" \"test/**/*.ts\" \"docs/**/*.ts\" --config ./.prettierrc --write",
     "fix:tslint": "npx tslint --fix --force -t verbose 'test/**/*.ts' 'src/**/*.ts' 'docs/**/*.ts'",
-    "test": "yarn build && yarn lint && yarn doc && yarn test:unit && npx snyk test && yarn test:integration",
+    "test": "yarn build && yarn lint && yarn doc && yarn test:unit && yarn test:integration",
     "test:unit": "npx jest --testPathIgnorePatterns \"./test/integration/require.test.ts\"",
     "test:integration": "node ./scripts/test-integration.js",
     "watch": "./scripts/tmux-start.sh",


### PR DESCRIPTION
Removing synk from CI because it's causing the test failures with following reasons:
1) auth issue: somehow $AUTH_TOKEN is not available in the env scope
2) snyk maximum test limits exceeded